### PR TITLE
Add __moduleName argument for relative paths resolution

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export default () => ({
         path.replaceWith(
           t.callExpression(
             t.memberExpression(t.identifier('System'), t.identifier('import')),
-            path.node.arguments,
+            path.node.arguments.concat(t.identifier('__moduleName')),
           ),
         );
       }

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export default () => ({
         path.replaceWith(
           t.callExpression(
             t.memberExpression(t.identifier('System'), t.identifier('import')),
-            path.node.arguments.concat(t.identifier('__moduleName')),
+            [path.node.arguments[0], t.identifier('__moduleName')],
           ),
         );
       }

--- a/test/fixtures/expected.js
+++ b/test/fixtures/expected.js
@@ -1,1 +1,1 @@
-const testModule = System.import('test-module').then(lol => lol.something());
+const testModule = System.import('test-module', __moduleName).then(lol => lol.something());


### PR DESCRIPTION
Fix to make relative imports work
```
import('./relative/path');
```